### PR TITLE
React style guide: Naming event functions in Props

### DIFF
--- a/styleguide/REACT.md
+++ b/styleguide/REACT.md
@@ -427,22 +427,20 @@
   export type { Props as ButtonProps };
   ```
 
-- Event handler props should start with `handle` or `on` followed by the event name.
+- Event handler props should use `on`, while component methods used as event handlers should use `handle` as prefix followed by the event name. eslint: [`react/jsx-handler-names`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md)
 
   ```tsx
   // bad
-  interface Props {
-    deleteItem: () => undefined;
-    selectItem: () => undefined;
-    submit: () => undefined;
-  }
+  <MyComponent handleChange={this.handleChange} />
+
+  // bad
+  <MyComponent onChange={this.componentChanged} />
 
   // good
-  interface Props {
-    handleDelete: () => undefined;
-    onSelect: () => undefined;
-    handleSubmit: () => undefined;
-  }
+  <MyComponent onChange={this.handleChange} />
+
+  // good
+  <MyComponent onChange={this.props.onFoo} />
   ```
 
 ## Refs

--- a/styleguide/REACT.md
+++ b/styleguide/REACT.md
@@ -427,20 +427,22 @@
   export type { Props as ButtonProps };
   ```
 
-- Event handler props should use `on`, while component methods used as event handlers should use `handle` as prefix followed by the event name. eslint: [`react/jsx-handler-names`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md)
+- Event handler props should use `on` as prefix followed by the event name.
+
+  > Why? Using a pattern for event handler prop names makes it easier to know the role of the prop. This way pattern matching can be used in Storybook to automatically catch [actions](https://storybook.js.org/docs/react/essentials/actions).
 
   ```tsx
   // bad
   <MyComponent handleChange={this.handleChange} />
 
   // bad
-  <MyComponent onChange={this.componentChanged} />
+  <MyComponent submit={this.handleSubmit} />
 
   // good
   <MyComponent onChange={this.handleChange} />
 
   // good
-  <MyComponent onChange={this.props.onFoo} />
+  <MyComponent onSubmit={this.handleSubmit} />
   ```
 
 ## Refs

--- a/styleguide/REACT.md
+++ b/styleguide/REACT.md
@@ -427,6 +427,24 @@
   export type { Props as ButtonProps };
   ```
 
+- Props which accept a function that will be called in case of an event should start with `on` followed by the event name.
+
+  ```tsx
+  // bad
+  interface Props {
+    handleDelete: () => undefined;
+    selectItem: () => undefined;
+    submit: () => undefined;
+  }
+
+  // good
+  interface Props {
+    onDelete: () => undefined;
+    onSelect: () => undefined;
+    onSubmit: () => undefined;
+  }
+  ```
+
 ## Refs
 
 - Always use ref callbacks. eslint: [`react/no-string-refs`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md)

--- a/styleguide/REACT.md
+++ b/styleguide/REACT.md
@@ -427,21 +427,21 @@
   export type { Props as ButtonProps };
   ```
 
-- Props which accept a function that will be called in case of an event should start with `on` followed by the event name.
+- Event handler props should start with `handle` or `on` followed by the event name.
 
   ```tsx
   // bad
   interface Props {
-    handleDelete: () => undefined;
+    deleteItem: () => undefined;
     selectItem: () => undefined;
     submit: () => undefined;
   }
 
   // good
   interface Props {
-    onDelete: () => undefined;
+    handleDelete: () => undefined;
     onSelect: () => undefined;
-    onSubmit: () => undefined;
+    handleSubmit: () => undefined;
   }
   ```
 


### PR DESCRIPTION
I noticed this mostly when updating stories for Storybook. Since Storybook can automatically catch actions by configuring a global regex. I set it to use `^(handle|on)[A-Z].*` for now, since some of the current event handler props are still using `handle` as prefix.
This way it will be easier to recognize what the prop will do.