### PR TITLE
Add typescript-sort-keys rules with warning

### DIFF
--- a/typescript-sort-keys.js
+++ b/typescript-sort-keys.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+  'typescript-sort-keys/interface': ['warn', 'asc', { natural: true }],
+  'typescript-sort-keys/string-enum': ['warn', 'asc', { natural: true }],
+};


### PR DESCRIPTION
- Add `typescript-sort-keys/interface` and `typescript-sort-keys/string-enum` rules from [eslint-plugin-typescript-sort-keys](https://github.com/infctr/eslint-plugin-typescript-sort-keys) with warning level.
- Fixes #5.