### PR TITLE
Update non-root configs

### DIFF
--- a/react.js
+++ b/react.js
@@ -1,17 +1,19 @@
 'use strict';
 
 module.exports = {
-  'react/destructuring-assignment': 'error',
-  'react/jsx-boolean-value': ['error', 'always', { never: ['global', 'jsx'] }],
-  'react/jsx-no-bind': 'error',
-  'react/jsx-pascal-case': 'error',
-  'react/jsx-uses-react': 'off',
-  'react/no-array-index-key': 'error',
-  'react/no-string-refs': 'error',
-  'react/no-unused-prop-types': 'error',
-  'react/prefer-es6-class': 'error',
-  'react/prefer-stateless-function': 'error',
-  'react/react-in-jsx-scope': 'off',
-  'react/require-render-return': 'error',
-  'react/static-property-placement': ['error', 'static public field'],
+  rules: {
+    'react/destructuring-assignment': 'error',
+    'react/jsx-boolean-value': ['error', 'always', { never: ['global', 'jsx'] }],
+    'react/jsx-no-bind': 'error',
+    'react/jsx-pascal-case': 'error',
+    'react/jsx-uses-react': 'off',
+    'react/no-array-index-key': 'error',
+    'react/no-string-refs': 'error',
+    'react/no-unused-prop-types': 'error',
+    'react/prefer-es6-class': 'error',
+    'react/prefer-stateless-function': 'error',
+    'react/react-in-jsx-scope': 'off',
+    'react/require-render-return': 'error',
+    'react/static-property-placement': ['error', 'static public field'],
+  },
 };

--- a/typescript-eslint.js
+++ b/typescript-eslint.js
@@ -1,17 +1,19 @@
 'use strict';
 
 module.exports = {
-  '@typescript-eslint/array-type': ['error', { default: 'generic' }],
-  '@typescript-eslint/ban-ts-comment': ['error', { 'ts-expect-error': 'allow-with-description' }],
-  '@typescript-eslint/explicit-module-boundary-types': 'off',
-  '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',
-  '@typescript-eslint/no-unnecessary-condition': 'error',
-  '@typescript-eslint/no-unused-vars': 'error',
-  '@typescript-eslint/prefer-for-of': 'error',
-  '@typescript-eslint/prefer-includes': 'error',
-  '@typescript-eslint/prefer-nullish-coalescing': 'error',
-  '@typescript-eslint/prefer-optional-chain': 'error',
-  '@typescript-eslint/prefer-string-starts-ends-with': 'error',
-  '@typescript-eslint/prefer-ts-expect-error': 'error',
-  '@typescript-eslint/restrict-plus-operands': 'error',
+  rules: {
+    '@typescript-eslint/array-type': ['error', { default: 'generic' }],
+    '@typescript-eslint/ban-ts-comment': ['error', { 'ts-expect-error': 'allow-with-description' }],
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',
+    '@typescript-eslint/no-unnecessary-condition': 'error',
+    '@typescript-eslint/no-unused-vars': 'error',
+    '@typescript-eslint/prefer-for-of': 'error',
+    '@typescript-eslint/prefer-includes': 'error',
+    '@typescript-eslint/prefer-nullish-coalescing': 'error',
+    '@typescript-eslint/prefer-optional-chain': 'error',
+    '@typescript-eslint/prefer-string-starts-ends-with': 'error',
+    '@typescript-eslint/prefer-ts-expect-error': 'error',
+    '@typescript-eslint/restrict-plus-operands': 'error',
+  },
 };

--- a/typescript-sort-keys.js
+++ b/typescript-sort-keys.js
@@ -1,6 +1,8 @@
 'use strict';
 
 module.exports = {
-  'typescript-sort-keys/interface': ['warn', 'asc', { natural: true }],
-  'typescript-sort-keys/string-enum': ['warn', 'asc', { natural: true }],
+  rules: {
+    'typescript-sort-keys/interface': ['warn', 'asc', { natural: true }],
+    'typescript-sort-keys/string-enum': ['warn', 'asc', { natural: true }],
+  },
 };


### PR DESCRIPTION
Non-root configs export eslint config objects. This way these can be used in extends. See [docs](https://eslint.org/docs/developer-guide/shareable-configs#sharing-multiple-configs).