### PR TITLE
Use TypeScript's no-shadow in TS files

### DIFF
--- a/typescript-eslint.js
+++ b/typescript-eslint.js
@@ -5,6 +5,7 @@ module.exports = {
     '@typescript-eslint/array-type': ['error', { default: 'generic' }],
     '@typescript-eslint/ban-ts-comment': ['error', { 'ts-expect-error': 'allow-with-description' }],
     '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-shadow': 'warn',
     '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',
     '@typescript-eslint/no-unnecessary-condition': 'error',
     '@typescript-eslint/no-unused-vars': 'error',
@@ -15,5 +16,6 @@ module.exports = {
     '@typescript-eslint/prefer-string-starts-ends-with': 'error',
     '@typescript-eslint/prefer-ts-expect-error': 'error',
     '@typescript-eslint/restrict-plus-operands': 'error',
+    'no-shadow': 'off', // replaced by TypeScript no-shadow
   },
 };


### PR DESCRIPTION
Using `no-shadow` in TypeScript files will trigger ESLint on enums as false positive:

>'StepName' is already declared in the upper scope. eslint(no-shadow)

Using TypeScript's rule instead in TS files will fix this.