### PR TITLE
feature: disallow _.concat (prefer native JS)

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,6 +83,11 @@ module.exports = {
       { message: 'Use Object.assign instead.', object: '_', property: 'assign' },
       { message: 'Use Math.ceil instead.', object: '_', property: 'ceil' },
       { message: 'Use the spread operator ... instead.', object: '_', property: 'clone' },
+      {
+        message: 'Use Array.concat or the spread operator ... instead.',
+        object: '_',
+        property: 'concat',
+      },
       { message: 'Use / operator instead.', object: '_', property: 'divide' },
       { message: 'Use a regular loop instead.', object: '_', property: 'each' },
       { message: 'Use String.endsWith instead.', object: '_', property: 'endsWith' },


### PR DESCRIPTION
This PR adds a rule to disallow the use of `_.concat`. It behaves identically to `Array.concat`, and as such we should move away from using it.