### PR TITLE
remove .only from restricted globals

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,8 +182,6 @@ module.exports = {
         object: '_',
         property: 'values',
       },
-      { object: 'describe', property: 'only' },
-      { object: 'it', property: 'only' },
     ],
     'no-return-assign': 'error',
     'no-return-await': 'error',


### PR DESCRIPTION
This PR removes `.only` from the list of restricted globals.

Instead of restricting it manually, we can use `eslint-plugin-mocha` to restrict it for us: https://github.com/zehitomo/z-api/pull/622